### PR TITLE
Temp outside of interval message

### DIFF
--- a/antoine.py
+++ b/antoine.py
@@ -74,7 +74,7 @@ def get_antoine_coef(Name, Temperature):
             index = None
 
     if index == None:
-        print('Sorry, the data for the given temperature {0}K does not exist in the Data Base', Temperature)
+        print('Sorry, the data for the given temperature %.2f K does not exist in the Data Base' % Temperature)
         return None
     else:
         A = As[index]


### PR DESCRIPTION
Changed print statement for temps outside of Antione coeff interval to output ###.## K rather than {0} K, where ###.## is the Temperature variable.